### PR TITLE
fix(#4): personality 입력 추가

### DIFF
--- a/demo/src/main/java/com/union/demo/dto/request/SignupReqDto.java
+++ b/demo/src/main/java/com/union/demo/dto/request/SignupReqDto.java
@@ -8,6 +8,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Map;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -26,6 +28,7 @@ public class SignupReqDto {
     private String username;
     private Long mainRoleId;
 
+    private Map<String, Integer> personality; //성격 정보 추가
 
     //user_profile
     private String email;
@@ -35,5 +38,6 @@ public class SignupReqDto {
     private String major;
     private Integer entranceYear;
     private Status status;
+
 
 }

--- a/demo/src/main/java/com/union/demo/service/AuthService.java
+++ b/demo/src/main/java/com/union/demo/service/AuthService.java
@@ -6,6 +6,8 @@ import com.union.demo.entity.Role;
 import com.union.demo.entity.University;
 import com.union.demo.entity.Users;
 import com.union.demo.enums.JwtRole;
+import com.union.demo.enums.PersonalityKey;
+import com.union.demo.enums.TeamCultureKey;
 import com.union.demo.repository.*;
 import com.union.demo.utill.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
@@ -16,6 +18,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 //jwt 기준
@@ -63,6 +67,25 @@ public class AuthService {
             throw new IllegalStateException("이미 사용중인 이름입니다.");
         }
     }
+    //personality convert
+    private Map<PersonalityKey, Integer> convertedPersonality(
+            Map<String, Integer> personality
+    ){
+        Map<PersonalityKey, Integer> convertedPersonality = new EnumMap<>(PersonalityKey.class);
+        if(personality!=null) {
+            for (Map.Entry<String, Integer> entry : personality.entrySet()) {
+                try {
+                    PersonalityKey key = PersonalityKey.valueOf(entry.getKey());
+                    convertedPersonality.put(key, entry.getValue());
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException(
+                            "잘못된 personality." + entry.getKey()
+                    );
+                }
+            }
+        }
+        return convertedPersonality;
+    }
 
     // users 정보 저장: user entity 생성(비밀번호 암호화 적용)
     private Users createUserEntity(SignupReqDto signupReqDto){
@@ -77,6 +100,7 @@ public class AuthService {
                 .password(bCryptPasswordEncoder.encode(signupReqDto.getPassword()))
                 .mainRoleId(mainRole)
                 .jwtRole(JwtRole.USER) //기본값은 USER
+                .personality(convertedPersonality(signupReqDto.getPersonality()))   //personality 변환
                 .build();
     }
 


### PR DESCRIPTION
# 🔎제목 : fix(#4): personality 입력 추가

##  ✅작업 내용

- 회원가입할 때 personality 정보 추가

  <br/>

## 📸이미지 첨부
<img width="1493" height="777" alt="image" src="https://github.com/user-attachments/assets/ba89b9d7-c088-4f14-93b3-bff66121d509" />


<br/>

## 📑앞으로의 과제

- me api(내 프로필, 포폴 crud 등등 api) 개발 진행 중...

  <br/>

## #️⃣이슈 링크

- https://github.com/2025-TEAM-LGTM/UniON-back/issues/4

<br/>