### PR TITLE
feat(#33): 멤버 포트폴리오 상세 조회

### DIFF
--- a/demo/src/main/java/com/union/demo/controller/MemberController.java
+++ b/demo/src/main/java/com/union/demo/controller/MemberController.java
@@ -1,12 +1,14 @@
 package com.union.demo.controller;
 
 import com.union.demo.dto.response.MemberListResDto;
+import com.union.demo.dto.response.PortfolioDetailResDto;
 import com.union.demo.dto.response.PortfolioListResDto;
 import com.union.demo.dto.response.ProfileResDto;
 import com.union.demo.enums.PersonalityKey;
 import com.union.demo.global.common.ApiResponse;
 import com.union.demo.service.MemberService;
 import com.union.demo.utill.PersonalityParserUtil;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -56,6 +58,15 @@ public class MemberController {
 
 
     //4. 팀원의 포트폴리오 상세 보기
+    @GetMapping("/{memberId}/portfolio/{portfolioId}")
+    public ResponseEntity<ApiResponse<PortfolioDetailResDto>> getMemberPortfolioDetail(
+            @PathVariable(required = true) Long memberId,
+            @PathVariable(required = true) Long portfolioId
+    ){
+        PortfolioDetailResDto data= memberService.getMemberPortfolioDetail(memberId, portfolioId);
+        return ResponseEntity.ok(ApiResponse.ok(data));
+
+    }
 
 
 }

--- a/demo/src/main/java/com/union/demo/service/MemberService.java
+++ b/demo/src/main/java/com/union/demo/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.union.demo.service;
 
 import com.union.demo.dto.response.MemberListResDto;
+import com.union.demo.dto.response.PortfolioDetailResDto;
 import com.union.demo.dto.response.PortfolioListResDto;
 import com.union.demo.dto.response.ProfileResDto;
 import com.union.demo.entity.Portfolio;
@@ -10,6 +11,7 @@ import com.union.demo.entity.Users;
 import com.union.demo.enums.PersonalityKey;
 import com.union.demo.repository.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -87,11 +89,25 @@ public class MemberService{
 
     //getMemberPortfolioList 함수: 팀원 포폴 리스트 조회
     public PortfolioListResDto getMemberPortfolioList(Long memberId){
-        Users user=userRepository.findByUserId(memberId)
+        userRepository.findByUserId(memberId)
                 .orElseThrow(()-> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         List<Portfolio> portfolio=portfolioRepository.findPortfolioByUserId(memberId);
 
         return PortfolioListResDto.from(portfolio);
+    }
+
+    //getMemberPortfolioDetail: 팀원의 상세 포트폴리오 조회
+    public PortfolioDetailResDto getMemberPortfolioDetail(Long memberId, Long portfolioId){
+       userRepository.findByUserId(memberId)
+               .orElseThrow(()-> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+        Portfolio portfolio=portfolioRepository.findDetailByPortfolioId(portfolioId)
+                .orElseThrow(()-> new NoSuchElementException("해당 포트폴리오를 찾을 수 없습니다."));
+
+        if(!portfolio.getUser().getUserId().equals(memberId)){
+            throw new AccessDeniedException("포트폴리오 작성자의 id와 memberId가 서로 다릅니다.");
+        }
+        return PortfolioDetailResDto.from(portfolio);
     }
 }


### PR DESCRIPTION
# 🔎제목 : feat(#33): 멤버 포트폴리오 상세 조회


##  ✅작업 내용

- 멤버 포트폴리오 상세 조회

  <br/>

## 📸이미지 첨부
<img width="1223" height="762" alt="image" src="https://github.com/user-attachments/assets/12fc676e-6c29-47f4-9647-cd81724e06c1" />


<br/>

## 📑앞으로의 과제

- post 쪽 api 완료짓기 + ai와의 연결

  <br/>

## #️⃣이슈 링크

- #33 

<br/>