### PR TITLE
feat(#35): 공고 지원하기

### DIFF
--- a/demo/src/main/java/com/union/demo/controller/PostApplicantController.java
+++ b/demo/src/main/java/com/union/demo/controller/PostApplicantController.java
@@ -1,9 +1,36 @@
 package com.union.demo.controller;
 
+import com.union.demo.dto.response.ApplyResDto;
+import com.union.demo.global.common.ApiResponse;
+import com.union.demo.service.PostApplicantService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts")
 public class PostApplicantController {
-    //1 공고에 지원하기  "/api/posts/{postId}/applicants"
+    private final PostApplicantService postApplicantService;
+
+    //1 공고에 지원하기  "/api/posts/{postId}/applications"
+    @PostMapping("/{postId}/applications")
+    public ResponseEntity<ApiResponse<ApplyResDto>> apply(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long postId
+    ){
+        ApplyResDto data= postApplicantService.apply(postId, userId);
+        return ResponseEntity.ok(ApiResponse.ok(data));
+    }
 
 
-    //2. 공고에 지원한 팀원 목록 필터 기능  /api/posts/{postId}/applicant?roleId=...&skillIds=1,2,3&p=
+    //2 공고 지원 취소하기
+
+
+    //3. 공고에 지원한 팀원 목록 필터 기능  /api/posts/{postId}/applicant?roleId=...&skillIds=1,2,3&p=
 
 }

--- a/demo/src/main/java/com/union/demo/controller/PostMatchingController.java
+++ b/demo/src/main/java/com/union/demo/controller/PostMatchingController.java
@@ -4,6 +4,8 @@ public class PostMatchingController {
     //1. 공고에 핏한 팀원 목록 보기 "/api/posts/{postId}/matches"
     //성향 일치 정보는 service에서 이루어짐
 
+
+
     //2. 공고에 핏한 팀원 필터기능 "/api/posts/123/matches?roleId=...&skillIds=1,2,3&p= "
 
 

--- a/demo/src/main/java/com/union/demo/dto/response/ApplyResDto.java
+++ b/demo/src/main/java/com/union/demo/dto/response/ApplyResDto.java
@@ -1,0 +1,27 @@
+package com.union.demo.dto.response;
+
+import com.union.demo.entity.Applicant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ApplyResDto {
+    private Long applyId;
+    private Long postId;
+    private Long applicantUserId;
+    private OffsetDateTime applyDate;
+
+    public static ApplyResDto from(Applicant app){
+        return ApplyResDto.builder()
+                .applyId(app.getApplyId())
+                .postId(app.getPost().getPostId())
+                .applicantUserId(app.getUser().getUserId())
+                .applyDate(app.getApplyDate())
+                .build();
+    }
+}

--- a/demo/src/main/java/com/union/demo/entity/Applicant.java
+++ b/demo/src/main/java/com/union/demo/entity/Applicant.java
@@ -11,7 +11,15 @@ import java.time.OffsetDateTime;
 
 @Entity
 @Getter
-@Table(name="post_apply")
+@Table(name="post_apply",
+    uniqueConstraints = {
+        @UniqueConstraint(
+                name="uk_post_user",
+                columnNames = {"post_id","user_id"}
+        )
+    }
+
+)
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Applicant {

--- a/demo/src/main/java/com/union/demo/repository/ApplicantRepository.java
+++ b/demo/src/main/java/com/union/demo/repository/ApplicantRepository.java
@@ -1,0 +1,10 @@
+package com.union.demo.repository;
+
+import com.union.demo.entity.Applicant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+    //중복 지원 방지용
+    boolean existsByPost_PostIdAndUser_UserId(Long postId, Long userId);
+
+}

--- a/demo/src/main/java/com/union/demo/service/PostApplicantService.java
+++ b/demo/src/main/java/com/union/demo/service/PostApplicantService.java
@@ -1,7 +1,67 @@
 package com.union.demo.service;
 
-public class PostApplicantService {
-    //1. applyPost 공고지원하기
+import com.union.demo.dto.response.ApplyResDto;
+import com.union.demo.entity.Applicant;
+import com.union.demo.entity.Post;
+import com.union.demo.entity.Users;
+import com.union.demo.enums.RecruitStatus;
+import com.union.demo.repository.ApplicantRepository;
+import com.union.demo.repository.PostRepository;
+import com.union.demo.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-    //2. getApplicants  공고에 지원한 사람들 조회 + 필터링
+import java.time.OffsetDateTime;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class PostApplicantService {
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final ApplicantRepository applicantRepository;
+
+    //1. applyPost 공고지원하기
+    @Transactional
+    public ApplyResDto apply(Long postId, Long userId){
+        //유저 확인
+        Users user=userRepository.findByUserId(userId)
+                .orElseThrow(()-> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        //공고 확인
+        Post post=postRepository.findByPostId(postId)
+                .orElseThrow(()-> new NoSuchElementException("해당 공고를 찾을 수 없습니다."));
+
+        //마감 공고 지원
+        if(post.getPostInfo().getStatus()!=RecruitStatus.OPEN) {
+            throw new IllegalStateException("마감된 공고에는 지원할 수 없습니다.");
+        }
+
+        //본인 공고에는 지원 불가
+        if(post.getLeaderId().getUserId().equals(userId)){
+            throw new IllegalStateException("본인 공고에는 지원할 수 없습니다.");
+        }
+
+
+        //중복 지원 체크
+        if(applicantRepository.existsByPost_PostIdAndUser_UserId(postId, userId)){
+            throw new IllegalStateException("이미 지원한 공고입니다.");
+        }
+
+        //지원하기
+        Applicant applicant=new Applicant(
+                null, post, user, OffsetDateTime.now()
+        );
+
+        Applicant saved=applicantRepository.save(applicant);
+
+        return ApplyResDto.from(saved);
+
+    }
+
+    //2 공고 지원 취소하기
+
+    //3. getApplicants  공고에 지원한 사람들 조회 + 필터링
 }


### PR DESCRIPTION
# 🔎제목 : feat(#35): 공고 지원하기

##  ✅작업 내용

- 공고에 지원하기
- 공고지원에 성공하면 200
- 이미 마감된 공고/본인 공고에 지원하기/이미 지원된 상태 --> 409 conflict 오류
- 해당 공고가 없음 --> 404 오류
- 그 외 오류는 500
- 오류를 더 세분화해서 보내줘야할까요..?

  <br/>

## 📸이미지 첨부
x

<br/>

## 📑앞으로의 과제

-  공고 지원 취소하기 기능 만들기
- 오류 코드를 세분화할 필요가 있는지 의논하기

  <br/>

## #️⃣이슈 링크

- #35 

<br/>