### PR TITLE
feat(#10): 지원여부, 현재 인원수 추가

### DIFF
--- a/demo/src/main/java/com/union/demo/controller/PostController.java
+++ b/demo/src/main/java/com/union/demo/controller/PostController.java
@@ -29,12 +29,13 @@ public class PostController {
     @Operation(summary = "전체 공고 목록 조회", description = "전체 목록 조회 + 쿼리를 통해 검색도 가능, 자세한 쿼리내용은 노션 api 문서 확인하기")
     @GetMapping
     public ResponseEntity<ApiResponse<PostListResDto>> getPosts(
+            @AuthenticationPrincipal Long userId,
             @RequestParam(required = false) List<Integer> domainIds,
             @RequestParam(required = false) List<Integer> fieldIds,
             @RequestParam(required = false) List<Integer> roleIds
 
     ){
-        PostListResDto data= postService.getAllPosts(domainIds, fieldIds, roleIds);
+        PostListResDto data= postService.getAllPosts(userId,domainIds, fieldIds, roleIds);
         return ResponseEntity.ok(ApiResponse.ok(data));
     }
 

--- a/demo/src/main/java/com/union/demo/dto/response/PostListResDto.java
+++ b/demo/src/main/java/com/union/demo/dto/response/PostListResDto.java
@@ -23,10 +23,21 @@ public class PostListResDto {
         private Long postId;
         private String title;
         private Integer dday;
-        private List<Integer> domainIds; //primeDomainId, secondDomainId
+        private List<ItemDto> domains; //primeDomainId, secondDomainId
         private List<RecruitDto> recruits;
+        //아래 두개 추가
+        private Integer nowCount; //현재 인원수
+        private boolean applied; //지원 여부
     }
 
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class ItemDto{
+        private Integer id;
+        private String name;
+    }
     @Getter
     @AllArgsConstructor
     @Builder

--- a/demo/src/main/java/com/union/demo/repository/ApplicantRepository.java
+++ b/demo/src/main/java/com/union/demo/repository/ApplicantRepository.java
@@ -2,14 +2,26 @@ package com.union.demo.repository;
 
 import com.union.demo.entity.Applicant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     //중복 지원 방지용
     boolean existsByPost_PostIdAndUser_UserId(Long postId, Long userId);
 
-    Optional<Applicant> findByPost_postIdAndUser_UserId(Long postId, Long userId);
+    //지원여부
+    @Query("""
+    select a.post.postId
+    from Applicant a
+    where a.user.userId = :userId and a.post.postId in :postIds
+
+""")
+    List<Long> findAppliedPostIds(@Param("userId") Long userId,
+                                  @Param("postIds") List<Long> postIds);
+    Optional<Applicant> findByPost_PostIdAndUser_UserId(Long postId, Long userId);
 
     void deleteByPost_PostIdAndUser_UserId(Long postId, Long userId);
 }

--- a/demo/src/main/java/com/union/demo/repository/PostCurrentRoleRepository.java
+++ b/demo/src/main/java/com/union/demo/repository/PostCurrentRoleRepository.java
@@ -21,4 +21,15 @@ public interface PostCurrentRoleRepository extends JpaRepository<PostCurrentRole
     where pcr.post.postId = :postId
 """)
     List<PostCurrentRole> findByPostIdWithCurrenRole(@Param("postId") Long postId);
+
+    //현재 총 몇명인지 세기
+    @Query("""
+    select pcr.post.postId as postId, sum(pcr.count) as nowCount
+    from PostCurrentRole pcr
+    where pcr.post.postId in :postIds
+    group by pcr.post.postId
+""")
+    List<PostNowCountRow> findNowCountByPostIds(@Param("postIds")List<Long> postIds);
+
+
 }

--- a/demo/src/main/java/com/union/demo/repository/PostNowCountRow.java
+++ b/demo/src/main/java/com/union/demo/repository/PostNowCountRow.java
@@ -1,0 +1,6 @@
+package com.union.demo.repository;
+
+public interface PostNowCountRow {
+    Long getPostId();
+    Integer getNowCount();
+}

--- a/demo/src/main/java/com/union/demo/service/PostApplicantService.java
+++ b/demo/src/main/java/com/union/demo/service/PostApplicantService.java
@@ -64,7 +64,7 @@ public class PostApplicantService {
     //2 공고 지원 취소하기
     @Transactional
     public ApplyResDto cancelApply(Long postId, Long userId){
-        Applicant applicant=applicantRepository.findByPost_postIdAndUser_UserId(postId, userId)
+        Applicant applicant=applicantRepository.findByPost_PostIdAndUser_UserId(postId, userId)
                 .orElseThrow(()-> new NoSuchElementException("지원 내역이 없습니다"));
 
         ApplyResDto res=ApplyResDto.from(applicant);


### PR DESCRIPTION
# 🔎제목 : feat(#10): 지원여부, 현재 인원수 추가

##  ✅작업 내용

- 공고 리스트 보여주는 부분에서 지원 여부, 현재 인원수 필드 추가
- 현재 인원수: nowCount : integer
- 지원 여부: appied : boolean
- 로그인 안한 상태 + 지원안한 상태 --> false
- 로그인했고 지원함 상태 --> true

  <br/>

## 📸이미지 첨부
x

<br/>

## 📑앞으로의 과제

- 고칠 부분 있으면 알려주세요

  <br/>

## #️⃣이슈 링크

- #10 

<br/>