### PR TITLE
feat(#41): portfolio update(patch)

### DIFF
--- a/demo/src/main/java/com/union/demo/config/SecurityConfig.java
+++ b/demo/src/main/java/com/union/demo/config/SecurityConfig.java
@@ -113,6 +113,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/refresh",
                                 "/api/auth/login",
+                                "/api/auth/username",
                                 "/api/auth/signup",
                                 "/api/auth/logout",
                                 "/swagger-ui.html",

--- a/demo/src/main/java/com/union/demo/controller/MeController.java
+++ b/demo/src/main/java/com/union/demo/controller/MeController.java
@@ -1,6 +1,7 @@
 package com.union.demo.controller;
 
 import com.union.demo.dto.request.PortfolioPostReqDto;
+import com.union.demo.dto.request.PortfolioUpdateReqDto;
 import com.union.demo.dto.request.ProfileUpdateReqDto;
 import com.union.demo.dto.response.ProfileResDto;
 import com.union.demo.dto.response.PortfolioDetailResDto;
@@ -87,4 +88,13 @@ public class MeController {
 
 
     //2.5 포트폴리오 수정하기 /api/me/portfolios/{portfolioId}
+    @PatchMapping("/portfolio/{portfolioId}")
+    public ResponseEntity<ApiResponse<PortfolioDetailResDto>> updatePortfolio(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long portfolioId,
+            @RequestBody PortfolioUpdateReqDto req
+    ){
+        PortfolioDetailResDto data=meService.updatePortfolio(userId, portfolioId, req);
+        return ResponseEntity.ok(ApiResponse.ok(data));
+    }
 }

--- a/demo/src/main/java/com/union/demo/controller/PostApplicantController.java
+++ b/demo/src/main/java/com/union/demo/controller/PostApplicantController.java
@@ -39,4 +39,5 @@ public class PostApplicantController {
 
     //3. 공고에 지원한 팀원 목록 필터 기능  /api/posts/{postId}/applicant?roleId=...&skillIds=1,2,3&p=
 
+
 }

--- a/demo/src/main/java/com/union/demo/controller/PostMatchController.java
+++ b/demo/src/main/java/com/union/demo/controller/PostMatchController.java
@@ -20,6 +20,8 @@ public class PostMatchController {
     public PostMatchResDto getPostMatch(@PathVariable Long postId){
         return postMatchService.postMatchFastApi(postId);
     }
+
+
     //2. 공고에 핏한 팀원 필터기능 "/api/posts/123/matches?roleId=...&skillIds=1,2,3&p= "
     // @GetMapping(".api/posts/{postId}/matches?role=Id")
 

--- a/demo/src/main/java/com/union/demo/dto/request/PortfolioUpdateReqDto.java
+++ b/demo/src/main/java/com/union/demo/dto/request/PortfolioUpdateReqDto.java
@@ -1,0 +1,33 @@
+package com.union.demo.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PortfolioUpdateReqDto {
+    @Size(max=255)
+    private String title;
+
+    @Size(max=255)
+    private String summary;
+
+    private Integer domainId;
+
+    private Integer roleId;
+
+    private Integer headcount;
+
+    private String externUrl;
+
+    private String Stext;
+
+    private String Ttext;
+
+    private String Atext;
+
+    private String Rtext;
+
+    private String imageUrl;
+}

--- a/demo/src/main/java/com/union/demo/entity/Portfolio.java
+++ b/demo/src/main/java/com/union/demo/entity/Portfolio.java
@@ -56,4 +56,54 @@ public class Portfolio extends BaseEntity{
     @Column(name="r_text", columnDefinition = "text")
     private String Rtext;
 
+
+    public void updateTitle(String title){
+        this.title=title;
+    }
+
+    public void updateHeadcount(Integer headcount){
+        this.headcount=headcount;
+    }
+
+    public void updateExternUrl(String externUrl){
+        this.externUrl=externUrl;
+    }
+
+    public void updateSummary(String summary){
+        this.summary=summary;
+    }
+
+    public void updateStext(String Stext){
+        this.Stext=Stext;
+    }
+
+    public void updateTtext(String Ttext){
+        this.Ttext=Ttext;
+    }
+
+    public void updateAtext(String Atext){
+        this.Atext=Atext;
+    }
+
+    public void updateRtext(String Rtext){
+        this.Rtext=Rtext;
+    }
+
+    public void updateImage(Image image){
+        this.image=image;
+    }
+
+    public void updateImageUrl(String imageUrl){
+
+    }
+
+    public void updateDomain(Domain domain){
+        this.domain=domain;
+    }
+
+    public void updateRole(Role role){
+        this.role=role;
+    }
+
+
 }

--- a/demo/src/main/java/com/union/demo/repository/PortfolioRepository.java
+++ b/demo/src/main/java/com/union/demo/repository/PortfolioRepository.java
@@ -25,6 +25,8 @@ order by p.portfolioId desc
 
     Optional<Portfolio> findDetailByPortfolioId(@Param("portfolioId") Long portfolioId);
 
+    Optional<Portfolio> findPortfolioByPortfolioId(Long portfolioId);
+
     void deletePortfolioByPortfolioId(Long portfolioId);
 
 }

--- a/demo/src/main/java/com/union/demo/service/MeService.java
+++ b/demo/src/main/java/com/union/demo/service/MeService.java
@@ -1,6 +1,7 @@
 package com.union.demo.service;
 
 import com.union.demo.dto.request.PortfolioPostReqDto;
+import com.union.demo.dto.request.PortfolioUpdateReqDto;
 import com.union.demo.dto.request.ProfileUpdateReqDto;
 import com.union.demo.dto.response.ProfileResDto;
 import com.union.demo.dto.response.PortfolioDetailResDto;
@@ -230,6 +231,83 @@ public class MeService {
 
 
     //5. updatePortfolio 포폴 수정
+    @Transactional
+    public PortfolioDetailResDto updatePortfolio(Long userId, Long portfolioId, PortfolioUpdateReqDto req){
+        //유저 확인
+        Users user=userRepository.findByUserId(userId)
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        //포트폴리오 확인
+        Portfolio portfolio=portfolioRepository.findPortfolioByPortfolioId(portfolioId)
+                .orElseThrow(()-> new NoSuchElementException("존재하지 않는 포트폴리오 입니다."));
+
+        //권한 확인: 로그인된 유저 == portfolio 작성자
+        if(!portfolio.getUser().getUserId().equals(user.getUserId())){
+            throw new IllegalArgumentException("본인 포트폴리오만 수정할 수 있습니다.");
+        }
+
+        //변경
+        if (req.getTitle() != null) {
+            portfolio.updateTitle(req.getTitle());
+        }
+        if (req.getSummary() != null) {
+            portfolio.updateSummary(req.getSummary());
+        }
+        if (req.getHeadcount() != null) {
+            portfolio.updateHeadcount(req.getHeadcount());
+        }
+        if (req.getExternUrl() != null) {
+            portfolio.updateExternUrl(req.getExternUrl());
+        }
+        if (req.getStext() != null) {
+            portfolio.updateStext(req.getStext());
+        }
+        if (req.getTtext() != null) {
+            portfolio.updateTtext(req.getTtext());
+        }
+        if (req.getAtext() != null) {
+            portfolio.updateAtext(req.getAtext());
+        }
+        if (req.getRtext() != null) {
+            portfolio.updateRtext(req.getRtext());
+        }
+
+        // domain 변경
+        if (req.getDomainId() != null) {
+            Domain domain = domainRepository.findByDomainId(req.getDomainId())
+                    .orElseThrow(() -> new NoSuchElementException("존재하지 않는 domainId 입니다."));
+            portfolio.updateDomain(domain);
+        }
+
+        // role 변경
+        if (req.getRoleId() != null) {
+            Role role = roleRepository.findByRoleId(req.getRoleId())
+                    .orElseThrow(() -> new NoSuchElementException("존재하지 않는 roleId 입니다."));
+            portfolio.updateRole(role);
+        }
+
+        // imageUrl 변경
+        // 코드 수정 필요
+        if (req.getImageUrl() != null) {
+            Image image = portfolio.getImage();
+
+            if (image == null) {
+                Image newImage = Image.builder()
+                        .imageUrl(req.getImageUrl())
+                        .build();
+                imageRepository.save(newImage);
+                portfolio.updateImage(newImage);
+            } else {
+                image.updateImageUrl(req.getImageUrl());
+            }
+        }
+
+        Portfolio updatedPortfolio=portfolioRepository.findPortfolioByPortfolioId(portfolioId)
+                .orElseThrow(()-> new NoSuchElementException("존재하지 않는 portfolio입니다."));
+
+        return PortfolioDetailResDto.from(updatedPortfolio);
+    }
+
 
     //6. deletePortfolio 포폴 삭제
     @Transactional


### PR DESCRIPTION
# 🔎제목 : feat(#41): portfolio update(patch)

##  ✅작업 내용

- 포트폴리오 수정하는 api 개발
- 수정된 필드만 req로 보냄
- 수정된 필드를 포함한 전체 포트폴리오 내용을 res로 보냄
- 200(성공), 400(로그인 필요). 404(domain id, role id 등 존재하지 않는 정보 존재), 500(서버 오류 및 수정권한없음)

  <br/>

## 📸이미지 첨부
x

<br/>

## 📑앞으로의 과제

- image 필드는 image 업로드 api를 완성한 이후에 다시 수정할 예정입니다.

  <br/>

## #️⃣이슈 링크

- https://github.com/2025-TEAM-LGTM/UniON-back/issues/41

<br/>